### PR TITLE
better to send some-batch of msg-block, instead of sending msg one-by-on...

### DIFF
--- a/src/main/java/com/vipshop/flume/KafkaUtil.java
+++ b/src/main/java/com/vipshop/flume/KafkaUtil.java
@@ -37,10 +37,10 @@ public class KafkaUtil {
 		log.info("PROPS:" + props);
 		return props;
 	}
-	public static Producer<String, String> getProducer(Context context) {
+	public static Producer<String, byte[]> getProducer(Context context) {
 		log.info(context.toString());
-		Producer<String, String> producer;
-		producer = new Producer<String, String>(new ProducerConfig(getKafkaConfigProperties(context)));
+		Producer<String, byte[]> producer;
+		producer = new Producer<String, byte[]>(new ProducerConfig(getKafkaConfigProperties(context)));
 		return producer;
 	}
 	public static ConsumerConnector getConsumer(Context context) throws IOException, KeeperException, InterruptedException {


### PR DESCRIPTION
better to send small-batch of msg-block, instead of sending msg one-by-one?

i have no environment of kafka-0.7.2, so i can't test-against it
in kafka-0.8 msg-list packaged-into-one-block, and send once

you can treat it as pseudo-code ^_^
